### PR TITLE
Support dynamic/static link to CRT

### DIFF
--- a/src/Make_msvc_dll.mak
+++ b/src/Make_msvc_dll.mak
@@ -37,7 +37,6 @@ OUTPUT_NAME = libXpm
 OUTPUT = $(OUTPUT_NAME).dll
 
 DEFINES =	/D_CRT_SECURE_NO_WARNINGS=1 \
-		/D_BIND_TO_CURRENT_VCLIBS_VERSION=1 \
 		/DFOR_MSW=1
 
 INCLUDES =	/I ..\include\X11
@@ -46,6 +45,13 @@ CCFLAGS =	$(DEFINES) $(INCLUDES) /wd 4996
 CPPFLAGS =	$(DEFINES) $(INCLUDES)
 
 LINKFLAGS =	/MAP:libXpm.map
+
+!ifdef USE_STATIC_CRT
+CVARS =		$(cvarsmt)
+!else
+CVARS =		$(cvarsdll)
+DEFINES =	$(DEFINES) /D_BIND_TO_CURRENT_VCLIBS_VERSION=1
+!endif
 
 ############################################################################
 # WINDOWS BUILD SETTINGS.
@@ -85,19 +91,19 @@ rebuild : clean tags build
 .PHONY: build clean rebuild
 
 .c.obj ::
-	$(CC) $(cdebug) $(cflags) $(cvarsdll) $(CCFLAGS) /c $<
+	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) /c $<
 
 .cpp.obj ::
-	$(CC) $(cdebug) $(cflags) $(cvarsdll) $(CPPFLAGS) /c $<
+	$(CC) $(cdebug) $(cflags) $(CVARS) $(CPPFLAGS) /c $<
 
 $(OUTPUT_NAME).exe : $(OBJS) $(RESOBJS)
-	$(link) $(ldebug) $(guilflags) $(guilibsdll) \
+	$(link) $(ldebug) $(guilflags) $(guilibs) \
 		/OUT:$@ $(LINKFLAGS) $(OBJS) $(RESOBJS) $(LIBS)
 	IF EXIST $@.manifest \
 	    mt -nologo -manifest $@.manifest -outputresource:$@;1
 
 $(OUTPUT_NAME).dll : $(OBJS) $(RESOBJS) $(DLLDEF)
-	$(link) /NOLOGO $(ldebug) $(dlllflags) $(conlibsdll) \
+	$(link) /NOLOGO $(ldebug) $(dlllflags) $(conlibs) \
 		/OUT:$@ /DEF:$(DLLDEF) $(LINKFLAGS) $(OBJS) $(RESOBJS) $(LIBS)
 	IF EXIST $@.manifest \
 	    mt -nologo -manifest $@.manifest -outputresource:$@;2

--- a/src/Make_msvc_lib.mak
+++ b/src/Make_msvc_lib.mak
@@ -4,9 +4,15 @@ SRC =	Attrib.c CrBufFrI.c CrDatFrI.c CrIFrBuf.c CrIFrDat.c Image.c Info.c \
 
 OBJ = $(SRC:.c=.obj)
 
-CFLAGS = /nologo /I../include/X11 /Ox /MD /W3 \
+CFLAGS = /nologo /I../include/X11 /Ox /W3 \
 	 /DFOR_MSW=1 \
 	 /D_CRT_SECURE_NO_WARNINGS=1
+
+!ifdef USE_STATIC_CRT
+CFLAGS = $(CFLAGS) /MT
+!else
+CFLAGS = $(CFLAGS) /MD
+!endif
 
 LFLAGS = /NOLOGO
 


### PR DESCRIPTION
If USE_MSVCRT is defined, msvcrXX.dll is linked.
Otherwise static CRT is linked.