### PR TITLE
Fix mingw build

### DIFF
--- a/src/Make_ming.mak
+++ b/src/Make_ming.mak
@@ -27,15 +27,18 @@ CFLAGS =	-I../include/X11 -I. \
 		-DFOR_MSW=1
 OBJS = $(subst .c,.o,$(SRCS))
 
+CC = gcc
+AR = ar
+
 all : libXpm.dll libXpm.a
 .c.o ::
-	gcc $(CFLAGS) -c $<
+	$(CC) $(CFLAGS) -c $<
 
 libXpm.dll : $(OBJS)
-	gcc -shared -o $@ $(OBJS) -lgdi32
+	$(CC) -shared -o $@ $(OBJS) -lgdi32
 
 libXpm.a : $(OBJS)
-	ar r $@ $?
+	$(AR) r $@ $?
 
 clean :
 	rm -f *.o *.dll *.a

--- a/src/Make_ming.mak
+++ b/src/Make_ming.mak
@@ -27,13 +27,16 @@ CFLAGS =	-I../include/X11 -I. \
 		-DFOR_MSW=1
 OBJS = $(subst .c,.o,$(SRCS))
 
-all : libXpm.dll
+all : libXpm.dll libXpm.a
 .c.o ::
 	gcc $(CFLAGS) -c $<
 
 libXpm.dll : $(OBJS)
 	gcc -shared -o $@ $(OBJS) -lgdi32
 
+libXpm.a : $(OBJS)
+	ar r $@ $?
+
 clean :
-	rm -f *.o *.dll
+	rm -f *.o *.dll *.a
 

--- a/src/WrFFrI.c
+++ b/src/WrFFrI.c
@@ -44,7 +44,6 @@
 
 #ifdef FOR_MSW
 # include <io.h>
-# include <fcntl.h>
 #endif
 
 #ifndef NO_ZPIPE

--- a/src/simx.h
+++ b/src/simx.h
@@ -103,9 +103,9 @@ extern "C" {
     FUNC(XDefaultDepth, int, (Display *d, Screen *s));
 
 /* color related */
-    FUNC(XParseColor, int, (Display *, Colormap, char *, XColor *));
+    FUNC(XParseColor, int, (Display *, Colormap *, char *, XColor *));
     FUNC(XAllocColor, int, (Display *, Colormap, XColor *));
-    FUNC(XQueryColors, void, (Display *display, Colormap colormap,
+    FUNC(XQueryColors, void, (Display *display, Colormap *colormap,
 			      XColor *xcolors, int ncolors));
     FUNC(XFreeColors, int, (Display *d, Colormap cmap,
 			    unsigned long pixels[],


### PR DESCRIPTION
MinGWでビルドが通らなかったので、 314441f0986bbeb7b54db54147bfd3c3b9f5eac8 の修正を一部revertしています。
ついでにMinGWでスタティックライブラリをビルドできるように修正しています。