### PR TITLE
Some fixes for win32 makefiles

### DIFF
--- a/src/Make_msvc_dll.mak
+++ b/src/Make_msvc_dll.mak
@@ -58,7 +58,12 @@ APPVER = 5.0
 TARGET = WINNT
 TARGETLANG = LANG_JAPANESE
 _WIN32_IE = 0x0600
+
+!IFDEF SDK_INCLUDE_DIR
+!INCLUDE $(SDK_INCLUDE_DIR)\Win32.Mak
+!ELSE
 !INCLUDE <Win32.Mak>
+!ENDIF
 
 ############################################################################
 # DON'T CHANGE BELOW.

--- a/src/Make_msvc_lib.mak
+++ b/src/Make_msvc_lib.mak
@@ -34,8 +34,6 @@ default: libXpm.lib
 clean:
 	-DEL /F $(OBJ)
 	-DEL /F libXpm.lib
-	-DEL /F libXpm.exp
-	-DEL /F libXpm.map
 
 libXpm.lib: $(OBJ)
 	LIB $(LFLAGS) $(OBJ) /OUT:libXpm.lib


### PR DESCRIPTION
Win32用makefileに以下の修正を行っています。
- VC2012以降には win32.mak が無いので、Vimと同じように `SDK_INCLUDE_DIR` が定義されていれば、そこから win32.mak を読み込む。
- *.lib のビルド時には、*.exp, *.map は生成されないので、clean の対象から除外。
